### PR TITLE
Support git repository checkouts using `git worktree`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,11 +8,19 @@ import (
 	"time"
 
 	"github.com/choffmeister/git-describe-semver/internal"
-	"github.com/go-git/go-git/v5"
 )
 
 func run(dir string, opts internal.GenerateVersionOptions) (*string, error) {
-	repo, err := git.PlainOpen(dir)
+	// enableCommonDir, err := git.ShouldEnableCommondDir(dir)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// openOpts := &git.PlainOpenOptions{EnableDotGitCommonDir: enableCommonDir}
+	// repo, err := git.PlainOpenWithOptions(dir, openOpts)
+	// if err != nil {
+	// 	return nil, fmt.Errorf("unable to open git repository: %v", err)
+	// }
+	repo, err := internal.OpenRepository(dir)
 	if err != nil {
 		return nil, fmt.Errorf("unable to open git repository: %v", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,15 +11,6 @@ import (
 )
 
 func run(dir string, opts internal.GenerateVersionOptions) (*string, error) {
-	// enableCommonDir, err := git.ShouldEnableCommondDir(dir)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// openOpts := &git.PlainOpenOptions{EnableDotGitCommonDir: enableCommonDir}
-	// repo, err := git.PlainOpenWithOptions(dir, openOpts)
-	// if err != nil {
-	// 	return nil, fmt.Errorf("unable to open git repository: %v", err)
-	// }
 	repo, err := internal.OpenRepository(dir)
 	if err != nil {
 		return nil, fmt.Errorf("unable to open git repository: %v", err)

--- a/internal/git.go
+++ b/internal/git.go
@@ -117,7 +117,11 @@ func GitDescribe(repo git.Repository) (*string, *int, *string, error) {
 }
 
 func OpenRepository(dir string) (*git.Repository, error) {
-	enableCommonDir, err := ShouldEnableCommondDir(dir)
+	gitDir, err := FindGitDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	enableCommonDir, err := shouldEnableCommondDir(gitDir)
 	if err != nil {
 		return nil, err
 	}
@@ -125,12 +129,7 @@ func OpenRepository(dir string) (*git.Repository, error) {
 	return git.PlainOpenWithOptions(dir, openOpts)
 }
 
-func ShouldEnableCommondDir(dir string) (bool, error) {
-	gitDir, err := FindGitDir(dir)
-	if err != nil {
-		return false, err
-	}
-
+func shouldEnableCommondDir(gitDir string) (bool, error) {
 	cdPath := filepath.Join(gitDir, CommonDirName)
 	st, err := os.Stat(cdPath)
 	if err != nil {

--- a/internal/git_test.go
+++ b/internal/git_test.go
@@ -181,3 +181,29 @@ func TestFindGitDir(t *testing.T) {
 		assert.Equal(actualDotGitPath, result)
 	})
 }
+
+func TestShouldEnableCommonDir(t *testing.T) {
+	t.Run(".git is a directory", func(t *testing.T) {
+		assert := assert.New(t)
+		testDir, gitDirPath := setUpDotGitDirTest(assert)
+		defer os.RemoveAll(testDir)
+
+		result, err := shouldEnableCommondDir(gitDirPath)
+		assert.NoError(err, "failed evaluating whether to enable commond dir")
+		assert.False(result)
+	})
+	t.Run(".git is a file pointing to another directory", func(t *testing.T) {
+		assert := assert.New(t)
+		testDir, actualDotGitPath, _ := setUpDotGitFileTest(assert)
+		defer os.RemoveAll(testDir)
+
+		cdPath := filepath.Join(actualDotGitPath, CommonDirName)
+		contents := "../my_worktree"
+		err := os.WriteFile(cdPath, []byte(contents), 0666)
+		assert.NoError(err, "failed writing commondir file")
+
+		result, err := shouldEnableCommondDir(actualDotGitPath)
+		assert.NoError(err, "failed evaluating whether to enable commond dir")
+		assert.True(result)
+	})
+}

--- a/internal/git_test.go
+++ b/internal/git_test.go
@@ -2,6 +2,8 @@ package internal
 
 import (
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-git/go-git/v5"
@@ -126,4 +128,24 @@ func TestGitDescribeWithBranch(t *testing.T) {
 	test("v1.0.0", 2, commit4.String())
 	repo.CreateTag("v2.0.0", commit3, nil)
 	test("v2.0.0", 1, commit4.String())
+}
+
+func TestFindGitDir(t *testing.T) {
+	t.Run(".git is a directory", func(t *testing.T) {
+		assert := assert.New(t)
+		testDir, err := os.MkdirTemp("", "test")
+		assert.NoError(err, "failed to create temp dir")
+		defer os.RemoveAll(testDir)
+
+		gitDirPath := filepath.Join(testDir, GitDirName)
+		err = os.Mkdir(gitDirPath, 0750)
+		assert.NoError(err, "failed to create git dir")
+
+		result, err := FindGitDir(testDir)
+		assert.NoError(err, "failed to find git dir")
+		assert.Equal(gitDirPath, result)
+	})
+	t.Run(".git is a file pointing to another directory", func(t *testing.T) {
+		t.Error("IMPLEMENT ME!")
+	})
 }

--- a/internal/git_test.go
+++ b/internal/git_test.go
@@ -146,6 +146,26 @@ func TestFindGitDir(t *testing.T) {
 		assert.Equal(gitDirPath, result)
 	})
 	t.Run(".git is a file pointing to another directory", func(t *testing.T) {
-		t.Error("IMPLEMENT ME!")
+		assert := assert.New(t)
+		testDir, err := os.MkdirTemp("", "test")
+		assert.NoError(err, "failed to create temp dir")
+		defer os.RemoveAll(testDir)
+
+		actualGitDirPath := filepath.Join(testDir, "actual")
+		err = os.Mkdir(actualGitDirPath, 0750)
+		assert.NoError(err, "failed to create actual git dir")
+
+		wtPath := filepath.Join(testDir, "my_worktree")
+		err = os.Mkdir(wtPath, 0750)
+		assert.NoError(err, "failed to create worktree dir")
+
+		wtGitPath := filepath.Join(wtPath, GitDirName)
+		wtGitContents := GitDirPrefix + actualGitDirPath
+		err = os.WriteFile(wtGitPath, []byte(wtGitContents), 0666)
+		assert.NoError(err, "failed to write git dir file in worktree")
+
+		result, err := FindGitDir(wtPath)
+		assert.NoError(err, "failed to find git dir in worktree")
+		assert.Equal(actualGitDirPath, result)
 	})
 }


### PR DESCRIPTION
Related to aspect-build/silo#353

When working with repository code using `git worktree`, the worktree's `.git` is a file that references the location of the worktree's git files. This location (i.e., directory) only contains pertinent data for that worktree. In addition, it has a file called `commondir` that specifies the location of the rest of the repository files. 

This PR updates `git-descrive-semver` to identify whether the current worktree uses the `commondir` mechanism. If so, it enables support for this mechanism in `go-git`.